### PR TITLE
Fix broken home links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 
-# Utils
-gem "rake"
-
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,12 +173,6 @@ GEM
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
-    rack (1.6.5)
-    rack-jekyll (0.5.0)
-      jekyll (>= 1.3)
-      listen (>= 1.3)
-      rack (~> 1.5)
-    rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -205,8 +199,6 @@ DEPENDENCIES
   jekyll (= 3.3.1)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
-  rack-jekyll
-  rake
 
 BUNDLED WITH
    1.14.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,0 @@
-require 'rake'
-
-desc "Do a thing"
-task :yay do
-  print "yay a task\n"
-end

--- a/_layouts/pages.html
+++ b/_layouts/pages.html
@@ -14,7 +14,7 @@
 
 <body>
 <main>
-  <p><a href="/">< Back to Home</a></p>
+  <p><a href="{{ site.baseurl }}/">< Back to Home</a></p>
   {{ content }}
 </main>
 </body>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -14,7 +14,7 @@
 
 <body>
 <main>
-  <p><a href="/">< Back to Home</a></p>
+  <p><a href="{{ site.baseurl }}/">< Back to Home</a></p>
   <a href="javascript:window.print();">Download this post</a>
   {{ content }}
 </main>

--- a/_pages/political-theory.md
+++ b/_pages/political-theory.md
@@ -9,7 +9,7 @@ categories: tests
 <ul>
   {% for post in site.posts %}
     <li>
-      <a href="{{ post.url }}">{{ post.title }}</a>
+      <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
- Use the `url` variable to reference the root site url
- Remove unused `rake` gem and `Rakefile`