### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _site/
 ## Environment normalization:
 /.bundle/
 /vendor/bundle
+
+## Editor settings
+.idea/


### PR DESCRIPTION
## Why?

Because sometimes editors like to add an `.idea` file. Looking at you, `RubyMine`.