### PR TITLE
Selectively hide page elements on print

### DIFF
--- a/_layouts/pages.html
+++ b/_layouts/pages.html
@@ -14,7 +14,7 @@
 
 <body>
 <main>
-  <p><a href="{{ site.baseurl }}/">< Back to Home</a></p>
+  <p class="no-print"><a href="{{ site.baseurl }}/">< Back to Home</a></p>
   {{ content }}
 </main>
 </body>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -17,7 +17,7 @@
   <p class="no-print"><a href="{{ site.baseurl }}/">< Back to Home</a></p>
   {{ content }}
   <footer class="no-print">
-    <a href="javascript:window.print();">Download this post</a>
+    <a href="javascript:window.print();">Print this post</a>
   </footer>
 </main>
 </body>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -14,9 +14,9 @@
 
 <body>
 <main>
-  <p><a href="{{ site.baseurl }}/">< Back to Home</a></p>
+  <p class="no-print"><a href="{{ site.baseurl }}/">< Back to Home</a></p>
   {{ content }}
-  <footer>
+  <footer class="no-print">
     <a href="javascript:window.print();">Download this post</a>
   </footer>
 </main>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -309,3 +309,9 @@ a:active {
     padding: 0 0 0 1.21875rem;
   }
 }
+
+@media print {
+  .no-print, .no-print * {
+    display: none !important;
+  }
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -15,5 +15,4 @@ time {
 footer {
   border-top: 1px solid $divider-color;
   padding: $base-spacing 0;
-  margin-top: $base-spacing;
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -14,5 +14,7 @@ time {
 
 footer {
   border-top: 1px solid $divider-color;
-  padding: $base-spacing 0;
+  text-align: center;
+  padding: $base-spacing;
+  margin-top: $base-spacing;
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -14,7 +14,6 @@ time {
 
 footer {
   border-top: 1px solid $divider-color;
-  text-align: center;
-  padding: $base-spacing;
+  padding: $base-spacing 0;
   margin-top: $base-spacing;
 }


### PR DESCRIPTION
## Why?

Since we use `window.print()` to print the page from the browser right now, it will pull in navigation elements, etc. We don't want these in our final study guide document, so we want to selectively hide them just for print. 

## What?

- Adds class `.no-print` to hide elements within `@media print`
- Adds `.no-print` to current page navigation and the anchor tag to print
- Also adds minor margin changes to the footer, so it's less crunched.

## How can/should this be manually tested?

[Visit any post](http://127.0.0.1:4000/sf-feminist-book-club/sister-outsider/) and click print at the bottom of the page.

## Screenshots (if appropriate)

Before:
![image](https://cloud.githubusercontent.com/assets/4473327/25033887/ce46c760-2096-11e7-84ac-8d5e9e20f221.png)

After: 
![image](https://cloud.githubusercontent.com/assets/4473327/25033869/97112aec-2096-11e7-9c95-943afb6ce8f8.png)

![bitmoji](https://render.bitstrips.com/v2/cpanel/9941680-239426165_2-s1-v1.png?transparent=1&palette=1&width=246)
