### PR TITLE
Fix date formatting

### DIFF
--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -4,12 +4,12 @@ layout: default
 
 <h1>{{ page.title }}</h1>
 
-<p>{{ page.datetime | datetime: "%B %-d, %Y @ %-I:%M %p" }}</p>
+<p>{{ page.datetime | date: "%B %-d, %Y @ %-I:%M %p" }}</p>
 <p>
   <a href="https://www.meetup.com/SF-Feminist-Book-Club/events/{{ page.meetup_identifier }}"
      target="_blank" >
-  {% capture now %}{{'now' | datetime: '%s'}}{% endcapture %}
-  {% capture event_time %}{{page.datetime | datetime: '%s'}}{% endcapture %}
+  {% capture now %}{{'now' | date: '%s'}}{% endcapture %}
+  {% capture event_time %}{{page.datetime | date: '%s'}}{% endcapture %}
   {% if event_time > now %}
     RSVP on Meetup
   {% else %}


### PR DESCRIPTION
## Why?

I broke date formatting when I switched `date` -> `datetime` in a few too many places.

## Screenshots (if appropriate)

Before:
![screen shot 2017-04-20 at 8 04 37 am](https://cloud.githubusercontent.com/assets/1860813/25237623/06d2c328-25a0-11e7-9d22-b4ba1ea390ef.png)

After:
![screen shot 2017-04-20 at 8 03 50 am](https://cloud.githubusercontent.com/assets/1860813/25237635/0c8c9b5e-25a0-11e7-98a4-d5bff271cb2c.png)
